### PR TITLE
Support for Non-Long Keys

### DIFF
--- a/src/main/scala/edu/berkeley/cs/amplab/spark/indexedrdd/IndexableRDD.scala
+++ b/src/main/scala/edu/berkeley/cs/amplab/spark/indexedrdd/IndexableRDD.scala
@@ -76,6 +76,13 @@ class IndexableRDD[K: ClassTag, V: ClassTag](ik: IndexableKey[K],
 object IndexableRDD extends Serializable {
   type Id = Long
 
+
+  /**
+   * The mapping between the key type and an id (Long)
+   * @note it is essential that for all possible K in the program toId(fromId(idval)) == idval
+   * @tparam K the type of the key (anything at all)
+   *
+   */
   trait IndexableKey[K] extends Serializable {
     def toId(key: K): Id
     def fromId(id: Id): K

--- a/src/main/scala/edu/berkeley/cs/amplab/spark/indexedrdd/IndexableRDD.scala
+++ b/src/main/scala/edu/berkeley/cs/amplab/spark/indexedrdd/IndexableRDD.scala
@@ -2,69 +2,115 @@ package edu.berkeley.cs.amplab.spark.indexedrdd
 
 import edu.berkeley.cs.amplab.spark.indexedrdd.IndexableRDD.IndexableKey
 import edu.berkeley.cs.amplab.spark.indexedrdd.IndexedRDD._
-import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.SparkContext._
 import org.apache.spark._
 import org.apache.spark.rdd.RDD
-import org.apache.spark.SparkContext._
 
-import scala.reflect.{classTag, ClassTag}
+import scala.reflect.ClassTag
 
 /**
  * An extension of the IndexedRDD which supports a wide variety of types
  * Created by mader on 2/23/15.
+ *
+ * @param ik the class for converting between keys and ids
+ * @param baseRDD made with an IndexedRDD to make it easier to perform map, filter, etc
+ * @tparam K the key of the dataset
+ * @tparam V the value (can be anything
  */
 class IndexableRDD[K: ClassTag, V: ClassTag](ik: IndexableKey[K],
-                                             val rawRDD:
-                                             RDD[(K,V)],
-                                              partr: Partitioner)
-  extends RDD[(K, V)](rawRDD.context, List(new OneToOneDependency(rawRDD))) {
+                                             baseRDD: IndexedRDD[V]) extends Serializable {
 
-  val baseRDD = IndexedRDD(rawRDD.map(kv => (ik.toId(kv._1),kv._2)))
+  /**
+   * An RDD that looks like it is supposed to
+   */
+  lazy val rawRDD = IndexableRDD.indexToKeys(ik,baseRDD)
 
   def get(key: K): Option[V] = multiget(Array(key)).get(key)
 
   def multiget(keys: Array[K]): Map[K,V] =
     baseRDD.multiget(keys.map(ik.toId)).map(kv => (ik.fromId(kv._1),kv._2))
 
-  @DeveloperApi
-  override def compute(split: Partition, context: TaskContext): Iterator[(K, V)] =
-    baseRDD.compute(split,context).map(kv => (ik.fromId(kv._1),kv._2))
+  /**
+   * Unconditionally updates the specified key to have the specified value. Returns a new
+   * IndexableRDD that reflects the modification.
+   */
+  def put(k: K, v: V): IndexableRDD[K,V] = multiput(Map(k -> v))
 
-  override protected def getPartitions: Array[Partition] = baseRDD.getPartitions
+  /**
+   * Unconditionally updates the keys in `kvs` to their corresponding values. Returns a new
+   * IndexedRDD that reflects the modification.
+   */
+  def multiput(kvs: Map[K, V]): IndexableRDD[K,V] =
+    new IndexableRDD(ik,baseRDD.multiput(kvs.map(kv => (ik.toId(kv._1),kv._2))))
+
+  /**
+   * Updates the keys in `kvs` to their corresponding values, running `merge` on old and new values
+   * if necessary. Returns a new IndexedRDD that reflects the modification.
+   */
+  def multiput(kvs: Map[K, V], merge: (K, V, V) => V): IndexableRDD[K,V] = {
+    val idMerge = (a: Id, b: V, c: V) => merge(ik.fromId(a),b,c)
+    new IndexableRDD(ik,baseRDD.multiput(kvs.map(kv => (ik.toId(kv._1),kv._2)),idMerge))
+  }
+
+  /**
+   * Restricts the entries to those satisfying the given predicate. This operation preserves the
+   * index for efficient joins with the original IndexedRDD and is implemented using soft deletions.
+   *
+   * @param pred the user defined predicate, which takes a tuple to conform to the `RDD[(K, V)]`
+   * interface
+   */
+  def filter(pred: Tuple2[K, V] => Boolean): IndexableRDD[K,V] = {
+    val idPred = (nt: Tuple2[Id,V]) => pred((ik.fromId(nt._1),nt._2))
+    new IndexableRDD(ik,baseRDD.filter(idPred))
+  }
+
+
+  def cache() = new IndexableRDD(ik,baseRDD.cache)
+
+  def collect() = rawRDD.collect()
+
+  def count() = rawRDD.count()
 }
+
 
 object IndexableRDD extends Serializable {
   type Id = Long
 
-  trait IndexableKey[K] {
+  trait IndexableKey[K] extends Serializable {
     def toId(key: K): Id
     def fromId(id: Id): K
   }
 
-
+  def keysToIndex[K: ClassTag, V: ClassTag](ik: IndexableKey[K],elems: RDD[(K, V)]) =
+    elems.mapPartitions(iter =>
+      (iter.map(kv=> (ik.toId(kv._1),kv._2))),
+      preservesPartitioning = true)
+  def indexToKeys[K: ClassTag, V: ClassTag](ik: IndexableKey[K],elems: RDD[(Id, V)]) =
+    elems.mapPartitions(iter =>
+      (iter.map(kv=> (ik.fromId(kv._1),kv._2))),
+      preservesPartitioning = true)
   /**
    * Constructs an IndexedRDD from an RDD of pairs, partitioning keys using a hash partitioner,
    * preserving the number of partitions of `elems`, and merging duplicate keys arbitrarily.
    */
   def apply[K: ClassTag, V: ClassTag](ik: IndexableKey[K],elems: RDD[(K, V)]): IndexableRDD[K,V] = {
-    IndexableRDD(ik, elems, elems.partitioner.getOrElse(new HashPartitioner(elems.partitions.size)))
+    new IndexableRDD(ik, IndexedRDD(keysToIndex(ik,elems)))
   }
 
   /** Constructs an IndexedRDD from an RDD of pairs, merging duplicate keys arbitrarily. */
   def apply[K: ClassTag, V: ClassTag](ik: IndexableKey[K], elems: RDD[(K, V)],
                                       partitioner: Partitioner):
   IndexableRDD[K,V] = {
-    IndexableRDD(ik, elems, partitioner, (a, b) => b)
+    val partitioned: RDD[(K, V)] = elems.partitionBy(partitioner)
+    new IndexableRDD(ik, IndexedRDD(keysToIndex(ik,partitioned)))
   }
 
   /** Constructs an IndexedRDD from an RDD of pairs. */
   def apply[K: ClassTag, V: ClassTag](ik: IndexableKey[K],
                           elems: RDD[(K, V)], partitioner: Partitioner,
                           mergeValues: (V, V) => V): IndexableRDD[K,V] = {
+
     val partitioned: RDD[(K, V)] = elems.partitionBy(partitioner)
-    val partitions = partitioned.mapPartitions(
-      iter => Iterator(IndexedRDDPartition(iter.map(kv => (ik.toId(kv._1),kv._2)), mergeValues)),
-      preservesPartitioning = true)
-    new IndexableRDD(ik,partitions)
+    new IndexableRDD(ik, IndexedRDD(keysToIndex(ik,partitioned),partitioner,mergeValues))
   }
 }

--- a/src/main/scala/edu/berkeley/cs/amplab/spark/indexedrdd/IndexableRDD.scala
+++ b/src/main/scala/edu/berkeley/cs/amplab/spark/indexedrdd/IndexableRDD.scala
@@ -1,0 +1,70 @@
+package edu.berkeley.cs.amplab.spark.indexedrdd
+
+import edu.berkeley.cs.amplab.spark.indexedrdd.IndexableRDD.IndexableKey
+import edu.berkeley.cs.amplab.spark.indexedrdd.IndexedRDD._
+import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark._
+import org.apache.spark.rdd.RDD
+import org.apache.spark.SparkContext._
+
+import scala.reflect.{classTag, ClassTag}
+
+/**
+ * An extension of the IndexedRDD which supports a wide variety of types
+ * Created by mader on 2/23/15.
+ */
+class IndexableRDD[K: ClassTag, V: ClassTag](ik: IndexableKey[K],
+                                             val rawRDD:
+                                             RDD[(K,V)],
+                                              partr: Partitioner)
+  extends RDD[(K, V)](rawRDD.context, List(new OneToOneDependency(rawRDD))) {
+
+  val baseRDD = IndexedRDD(rawRDD.map(kv => (ik.toId(kv._1),kv._2)))
+
+  def get(key: K): Option[V] = multiget(Array(key)).get(key)
+
+  def multiget(keys: Array[K]): Map[K,V] =
+    baseRDD.multiget(keys.map(ik.toId)).map(kv => (ik.fromId(kv._1),kv._2))
+
+  @DeveloperApi
+  override def compute(split: Partition, context: TaskContext): Iterator[(K, V)] =
+    baseRDD.compute(split,context).map(kv => (ik.fromId(kv._1),kv._2))
+
+  override protected def getPartitions: Array[Partition] = baseRDD.getPartitions
+}
+
+object IndexableRDD extends Serializable {
+  type Id = Long
+
+  trait IndexableKey[K] {
+    def toId(key: K): Id
+    def fromId(id: Id): K
+  }
+
+
+  /**
+   * Constructs an IndexedRDD from an RDD of pairs, partitioning keys using a hash partitioner,
+   * preserving the number of partitions of `elems`, and merging duplicate keys arbitrarily.
+   */
+  def apply[K: ClassTag, V: ClassTag](ik: IndexableKey[K],elems: RDD[(K, V)]): IndexableRDD[K,V] = {
+    IndexableRDD(ik, elems, elems.partitioner.getOrElse(new HashPartitioner(elems.partitions.size)))
+  }
+
+  /** Constructs an IndexedRDD from an RDD of pairs, merging duplicate keys arbitrarily. */
+  def apply[K: ClassTag, V: ClassTag](ik: IndexableKey[K], elems: RDD[(K, V)],
+                                      partitioner: Partitioner):
+  IndexableRDD[K,V] = {
+    IndexableRDD(ik, elems, partitioner, (a, b) => b)
+  }
+
+  /** Constructs an IndexedRDD from an RDD of pairs. */
+  def apply[K: ClassTag, V: ClassTag](ik: IndexableKey[K],
+                          elems: RDD[(K, V)], partitioner: Partitioner,
+                          mergeValues: (V, V) => V): IndexableRDD[K,V] = {
+    val partitioned: RDD[(K, V)] = elems.partitionBy(partitioner)
+    val partitions = partitioned.mapPartitions(
+      iter => Iterator(IndexedRDDPartition(iter.map(kv => (ik.toId(kv._1),kv._2)), mergeValues)),
+      preservesPartitioning = true)
+    new IndexableRDD(ik,partitions)
+  }
+}

--- a/src/main/scala/edu/berkeley/cs/amplab/spark/indexedrdd/IndexedRDD.scala
+++ b/src/main/scala/edu/berkeley/cs/amplab/spark/indexedrdd/IndexedRDD.scala
@@ -80,4 +80,18 @@ object IndexedRDD {
       preservesPartitioning = true)
     new IndexedRDD(partitions)
   }
+
+  /** Create an IndexedRdd from a non-long type and a conversion function
+    *
+    * @param rawRdd the original RDD
+    * @param createIndex a function to convert the type K into Long
+    * @tparam K the type of the image
+    * @tparam V the type of the data
+    */
+  def apply[K: ClassTag, V: ClassTag](
+                        rawRdd: RDD[(K,V)],
+                                     createIndex: K => Id
+                          ) = {
+
+  }
 }

--- a/src/main/scala/edu/berkeley/cs/amplab/spark/indexedrdd/IndexedRDD.scala
+++ b/src/main/scala/edu/berkeley/cs/amplab/spark/indexedrdd/IndexedRDD.scala
@@ -80,18 +80,4 @@ object IndexedRDD {
       preservesPartitioning = true)
     new IndexedRDD(partitions)
   }
-
-  /** Create an IndexedRdd from a non-long type and a conversion function
-    *
-    * @param rawRdd the original RDD
-    * @param createIndex a function to convert the type K into Long
-    * @tparam K the type of the image
-    * @tparam V the type of the data
-    */
-  def apply[K: ClassTag, V: ClassTag](
-                        rawRdd: RDD[(K,V)],
-                                     createIndex: K => Id
-                          ) = {
-
-  }
 }

--- a/src/test/scala/edu/berkeley/cs/amplab/spark/indexedrdd/IndexableRDDSuite.scala
+++ b/src/test/scala/edu/berkeley/cs/amplab/spark/indexedrdd/IndexableRDDSuite.scala
@@ -71,8 +71,12 @@ object IndexableRDDSuite {
 
   case class Point3D(x: Int, y: Int, z: Int)
 
+
+  /**
+   * offers translation for positive Point3D between 0,0,0 and 99,99,99
+   */
   val p3dKey = new IndexableKey[Point3D] {
-    override def toId(key: Point3D): Id = 1000*key.z+100*key.y+key.x
+    override def toId(key: Point3D): Id = (100*key.z+key.y)*100+key.x
 
     override def fromId(id: Id): Point3D =
       Point3D(

--- a/src/test/scala/edu/berkeley/cs/amplab/spark/indexedrdd/IndexableRDDSuite.scala
+++ b/src/test/scala/edu/berkeley/cs/amplab/spark/indexedrdd/IndexableRDDSuite.scala
@@ -1,0 +1,58 @@
+package edu.berkeley.cs.amplab.spark.indexedrdd
+
+
+import edu.berkeley.cs.amplab.spark.indexedrdd.IndexableRDD.{Id, IndexableKey}
+import org.apache.spark.SparkContext
+import org.scalatest.FunSuite
+
+import scala.collection.immutable.LongMap
+
+/**
+ * Created by mader on 2/23/15.
+ */
+class IndexableRDDSuite extends FunSuite with SharedSparkContext  {
+
+  case class IdString(x: String)
+
+  val idsKey = new IndexableKey[IdString] {
+    override def toId(key: IdString): Id = key.x.toLong
+    override def fromId(id: Id): IdString = IdString(id.toString)
+  }
+
+  case class Point3D(x: Int, y: Int, z: Int)
+
+  val p3dKey = new IndexableKey[Point3D] {
+    override def toId(key: Point3D): Id = 1000*key.z+100*key.y+key.x
+
+    override def fromId(id: Id): Point3D =
+      Point3D(
+        Math.floor(id/1000).toInt,
+        Math.floor((id % 1000)/100).toInt,
+        (id%100).toInt
+      )
+  }
+  def pairsP3D(sc: SparkContext, n: Int) = {
+    IndexableRDD(p3dKey,sc.parallelize((0 to n).map(x => (Point3D(x,x,x), x)), 5))
+  }
+  def pairsIds(sc: SparkContext, n: Int) = {
+    IndexableRDD(idsKey,sc.parallelize((0 to n).map(x => (IdString(x.toString()), x)), 5))
+  }
+  val n = 99
+
+  test("get, multiget") {
+
+    val ps = pairsP3D(sc, n).cache()
+    assert(ps.get(-1L) === None, "Standard index based method for null elements")
+    assert(ps.get(0L) === Some(0),"Get the first element")
+    assert(ps.get(Point3D(0,0,0)) === Some(0), "Get the first point")
+    assert(ps.get(Point3D(99,99,99)) === Some(99), "Get the last point")
+
+  }
+
+  test("filter on IndexableRDD") {
+    val ps = pairsP3D(sc, n).cache()
+    val evens = ps.filter(q => ((q._2 % 2) == 0)).cache()
+    assert(evens.multiget(Array(-1L, 0L, 1L, 98L)) === LongMap(0L -> 0, 98L -> 98))
+    assert(evens.get(97L) === None)
+  }
+}


### PR DESCRIPTION
A proposed addition to have non-Long keys using the `IndexableRDD` which is a thin class on top of IndexedRDD and has a conversion between a key of any type and a Long using the provided `IndexableKey` class. Only some of the functions have currently been implemented, but it is fairly straightforward to implement the rest as needed.
