### PR TITLE
add sbt-spark-package plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,11 +11,17 @@ organization := "edu.berkeley.cs.amplab"
 
 scalaVersion := "2.10.4"
 
-libraryDependencies += "org.apache.spark" %% "spark-core" % "1.1.0"
+spName := "amplab/spark-indexedrdd"
+
+sparkVersion := "1.1.0"
+
+sparkComponents += "core"
 
 libraryDependencies += "com.google.guava" % "guava" % "14.0.1"
 
 publishMavenStyle := true
+
+licenses += "Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")
 
 publishTo := {
   val nexus = "https://oss.sonatype.org/"
@@ -27,13 +33,6 @@ publishTo := {
 
 pomExtra := (
   <url>https://github.com/amplab/spark-indexedrdd</url>
-  <licenses>
-    <license>
-      <name>Apache License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
-      <distribution>repo</distribution>
-    </license>
-  </licenses>
   <scm>
     <url>git@github.com:amplab/spark-indexedrdd.git</url>
     <connection>scm:git:git@github.com:amplab/spark-indexedrdd.git</connection>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -34,3 +34,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8")
 libraryDependencies += "org.ow2.asm"  % "asm" % "5.0.3"
 
 libraryDependencies += "org.ow2.asm"  % "asm-commons" % "5.0.3"
+
+resolvers += "Spark Package Main Repo" at "https://dl.bintray.com/spark-packages/maven"
+
+addSbtPlugin("org.spark-packages" % "sbt-spark-package" % "0.2.0")


### PR DESCRIPTION
After adding credentials to `build.sbt`, a new version can be released using `sbt spPublish`

https://github.com/databricks/sbt-spark-package
