### PR TITLE
Fix SBT download

### DIFF
--- a/sbt/sbt-launch-lib.bash
+++ b/sbt/sbt-launch-lib.bash
@@ -38,7 +38,7 @@ dlog () {
 
 acquire_sbt_jar () {
   SBT_VERSION=`awk -F "=" '/sbt\\.version/ {print $2}' ./project/build.properties`
-  URL1=http://typesafe.artifactoryonline.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/${SBT_VERSION}/sbt-launch.jar
+  URL1=http://dl.bintray.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/${SBT_VERSION}/sbt-launch.jar
   URL2=http://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/${SBT_VERSION}/sbt-launch.jar
   JAR=sbt/sbt-launch-${SBT_VERSION}.jar
 
@@ -51,7 +51,7 @@ acquire_sbt_jar () {
     printf "Attempting to fetch sbt\n"
     JAR_DL="${JAR}.part"
     if hash curl 2>/dev/null; then
-      (curl --silent ${URL1} > "${JAR_DL}" || curl --silent ${URL2} > "${JAR_DL}") && mv "${JAR_DL}" "${JAR}"
+      (curl -L --silent ${URL1} > "${JAR_DL}" || curl -L --silent ${URL2} > "${JAR_DL}") && mv "${JAR_DL}" "${JAR}"
     elif hash wget 2>/dev/null; then
       (wget --quiet ${URL1} -O "${JAR_DL}" || wget --quiet ${URL2} -O "${JAR_DL}") && mv "${JAR_DL}" "${JAR}"
     else


### PR DESCRIPTION
- Fixes error "Invalid or Corrupt jar file" when running sbt, by applying equivalent change from https://github.com/databricks/spark-perf/pull/78

Typesafe has deprecated artifactoryonline in favor of bintray, as announced in this blog post.
https://www.typesafe.com/blog/migrating-repos-to-bintray

This results in sbt-launch-lib.bash to fail in downloading SBT, leading to an error:

> Attempting to fetch sbt
> Launching sbt from sbt/sbt-launch-0.13.6.jar
> Error: Invalid or corrupt jarfile sbt/sbt-launch-0.13.6.jar

This change updates the repo URL and fixes the curl command to handle 3xx redirects properly.

Props to @feynmanliang for the pointer to this fix :)
